### PR TITLE
删除一个致谢中被误判的错误：本科毕业论文or硕士毕业论文

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,12 +625,6 @@
 
 问号和逗号连用。  
 
-51. 文字错误(第六十八页致谢部分倒数第三段内容)：  
-
->本科毕业论文致谢的最后，我引了 Carl Sagan 所说的： 
-
-这不是**硕士**毕业论文吗？怎么写的本科？不会连致谢都是抄的吧？  
-
 52. 标点符号错误(第六十八页致谢部分倒数第二段内容)：  
 
 >We make our world significant by the courage of our questions and by the depth of our answers。 


### PR DESCRIPTION
致谢里，杨女士提到“**本科毕业论文**致谢的最后，我引了 Carl Sagan 所说的”，这与后文“**那时的我**尚未确定之后的职业规划”对应。也即是说，杨女士在这里只是引用了自己本科论文里的致谢，而不是把“硕士毕业论文”错误地写成了“本科毕业论文”。