### PR TITLE
添加Issues模板，并关联label，便于管理

### DIFF
--- a/.github/ISSUE_TEMPLATE/发起闲聊.md
+++ b/.github/ISSUE_TEMPLATE/发起闲聊.md
@@ -1,0 +1,10 @@
+---
+name: 发起闲聊
+about: 发起与论文自身问题无关的闲聊/讨论
+title: ''
+labels: wontfix
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/报告论文错误.md
+++ b/.github/ISSUE_TEMPLATE/报告论文错误.md
@@ -1,0 +1,10 @@
+---
+name: 报告论文错误
+about: 指出论文具体错误和相关依据
+title: ''
+labels: documentation, enhancement, help wanted
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
添加了“发起闲聊”（关联“wontfix”）以及“报告论文错误”（关联“documentation”等）两种issue模板，便于管理人员筛查信息并完善文稿，效果如下图。
<img width="1770" height="701" alt="image" src="https://github.com/user-attachments/assets/90e5c255-d945-44f8-a484-40f26b63e61e" />
